### PR TITLE
Fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # chartjs.github.io
 
-This is the [Chart.js](www.chartjs.org) site hosted on GitHub Pages.
+This is the [Chart.js](http://www.chartjs.org) site hosted on GitHub Pages.


### PR DESCRIPTION
Without the 'http://' prefix, the link redirects to https://github.com/chartjs/chartjs.github.io/blob/master/www.chartjs.org